### PR TITLE
Add Packrift ecommerce carton CSV example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -41,6 +41,9 @@ Items only (no boxes). Will use default boxes from the system. Format without ty
 ### `case-6-challenge.csv`
 Challenge case with large boxes and large items requiring careful packing strategy.
 
+### `packrift-ecommerce-cartons.csv`
+Ecommerce cartonization fixture derived from Packrift's public solver fixture pack. Includes four carton sizes and eight ecommerce order items converted from inches to millimeters for visual debugging.
+
 ## Legacy Examples (with IDs)
 
 These examples use the old format with IDs (still supported):
@@ -80,4 +83,3 @@ The importer supports multiple formats:
 - IDs are automatically generated (no need to specify)
 - All dimensions must be positive numbers
 - Type must be exactly `0` (box) or `1` (item) if specified
-

--- a/examples/packrift-ecommerce-cartons.csv
+++ b/examples/packrift-ecommerce-cartons.csv
@@ -1,0 +1,20 @@
+# Packrift ecommerce cartonization fixture
+# Source: https://packrift.github.io/packaging-optimization-benchmark-corpus/cartonization-solver-fixtures.html
+# Dimensions converted from inches to millimeters for BoxPacker3 UI.
+# Format: width;height;depth;weight;type
+
+# Boxes
+254;152;152;20000;0
+508;356;152;20000;0
+610;254;203;20000;0
+1016;508;508;30000;0
+
+# Items
+191;114;89;454;1
+381;178;64;680;1
+381;178;64;680;1
+533;216;127;1361;1
+457;305;140;1814;1
+457;305;140;1814;1
+457;305;140;1814;1
+457;305;140;1814;1


### PR DESCRIPTION
## Summary
- add a Packrift-derived ecommerce cartonization CSV sample for the import examples
- document the sample in the examples README
- keep the fixture as static dimensions converted to millimeters for BoxPacker3 UI visual debugging

## Validation
- `node` CSV validation confirmed 4 boxes and 8 items parse as valid simplified import rows
- `npm run build` passed locally; generated bundle output was not committed because it changes from a clean checkout independent of this example-only change
- `git diff --check` passed

Source fixture: https://packrift.github.io/packaging-optimization-benchmark-corpus/cartonization-solver-fixtures.html
